### PR TITLE
Implement generic proxy rewriting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## Proxy behaviour
+
+Set `NEXT_PUBLIC_EXTERNAL_API_BASE_URL` in your environment. Any request to
+`/<service>/api/v1/*` will be forwarded to
+`${NEXT_PUBLIC_EXTERNAL_API_BASE_URL}/<service>/api/v1/*`.
+
+
 ## Getting Started
 
 First, run the development server:

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async rewrites() {
+    const base = process.env.NEXT_PUBLIC_EXTERNAL_API_BASE_URL || "";
+    return [
+      {
+        source: "/:service/api/v1/:path*",
+        destination: `${base}/:service/api/v1/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/utils/externalApiClient.tsx
+++ b/src/utils/externalApiClient.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const apiClient = axios.create({
-    baseURL: process.env.NEXT_PUBLIC_EXTERNAL_API_BASE_URL || 'http://localhost:8080',
+    baseURL: process.env.NEXT_PUBLIC_EXTERNAL_API_BASE_URL || '',
 });
 
 export default apiClient;


### PR DESCRIPTION
## Summary
- configure Next.js rewrites to forward `/:service/api/v1/:path*` to an external base URL
- allow the axios client to use a blank `NEXT_PUBLIC_EXTERNAL_API_BASE_URL`
- document the proxy behaviour in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ffa1b6a4c832f85b107fa2a620c55